### PR TITLE
Hook up custom domain showranks.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ These rules apply to every session in this repo. Read them before doing any work
 ## Deployment
 
 - The site auto-deploys to GitHub Pages on every push to `main` via `.github/workflows/pages.yml`.
-- Live URL: https://anduaura.github.io/netflix-ranking/
+- Live URL: https://showranks.com (custom domain set via the `CNAME` file at repo root). The GitHub Pages default `https://anduaura.github.io/netflix-ranking/` redirects to the custom domain once Pages applies the setting.
 - After pushing user-visible changes, you can verify by curling that URL once Pages has had ~30–60s to redeploy.
 
 ## Data refresh

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+showranks.com

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An interactive ranking of Netflix originals and exclusives sorted by IMDb rating. Pure static site — no backend, no build step, deployable for free on GitHub Pages.
 
-**Live site:** https://anduaura.github.io/netflix-ranking/
+**Live site:** https://showranks.com
 
 ## Features
 


### PR DESCRIPTION
Lands the CNAME file + URL updates that the local sandbox proxy was rejecting on direct push to main.

CNAME file tells GitHub Pages to serve at showranks.com instead of anduaura.github.io/netflix-ranking. Pages will provision a Let's Encrypt cert automatically once DNS resolves.

Brand-neutral domain by design — site copy stays Netflix-focused, but the URL doesn't lock us in if scope ever expands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLWi2WhCzYTqXn4UsV6oAV)_