### PR TITLE
Use BOT_PUSH_TOKEN PAT for refresh workflow's git push

### DIFF
--- a/.github/workflows/refresh-ratings.yml
+++ b/.github/workflows/refresh-ratings.yml
@@ -20,7 +20,19 @@ jobs:
       TMDB_API_KEY: ${{ secrets.TMDB_API_KEY }}
       OMDB_API_KEY: ${{ secrets.OMDB_API_KEY }}
     steps:
+      # The PAT (BOT_PUSH_TOKEN) authenticates this checkout's git remote
+      # so subsequent `git push` calls authenticate as the PAT's owner
+      # (the repo admin). This satisfies the branch ruleset's "Repository
+      # admin" bypass entry — without it, the default GITHUB_TOKEN would
+      # push as github-actions[bot] which can't bypass branch protection
+      # in personal repos.
+      #
+      # If BOT_PUSH_TOKEN is unset, checkout falls back to GITHUB_TOKEN
+      # and the workflow still runs; the push step will fail loudly if
+      # branch protection blocks it.
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PUSH_TOKEN || secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,8 @@ These rules apply to every session in this repo. Read them before doing any work
 1. **`scripts/refresh_catalog.py`** — grows `shows.json` incrementally from TMDb's Netflix discover endpoint using a rotating page cursor stored inside the file. Existing entries are never modified by this step. Requires `TMDB_API_KEY` secret; if missing, the step is skipped (warning, not failure).
 2. **`scripts/refresh_ratings.py`** — sharded LRU refresh of IMDb ratings via OMDb. Picks the `OMDB_DAILY_BUDGET` entries with the oldest `rating_refreshed_at` and updates them. Requires `OMDB_API_KEY` secret.
 
+The workflow's `actions/checkout` step authenticates with `secrets.BOT_PUSH_TOKEN` — a fine-grained PAT owned by the repo admin (`anduaura`). Required because the `main` branch ruleset requires PRs from non-admin actors, and the default `GITHUB_TOKEN` pushes as `github-actions[bot]`, which isn't a bypass actor in personal-repo rulesets. The PAT inherits the admin bypass entry and can push directly. If the PAT ever needs to be rotated, the only place to update is the secret value at `Settings → Secrets and variables → Actions → BOT_PUSH_TOKEN`.
+
 **Architectural rules:**
 - **Limits are named constants** at the top of each script (`OMDB_DAILY_BUDGET`, `TMDB_PAGES_PER_RUN`, `TMDB_MIN_VOTE_COUNT`, `CATALOG_MAX_SIZE`, `TMDB_REGION`, etc.). Never inline magic numbers in the body of the scripts. When tuning, change the constant.
 - **Fail fast on auth/quota errors** (exit codes 3 / 4). Never retry through a doomed budget.


### PR DESCRIPTION
Switches the refresh-ratings workflow's checkout to use the BOT_PUSH_TOKEN PAT (admin-owned) so git pushes authenticate as admin and inherit the ruleset's "Repository admin" bypass. Falls back to GITHUB_TOKEN when the secret is unset.

Documented in CLAUDE.md: where the PAT lives, why GITHUB_TOKEN can't substitute, and how to rotate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLWi2WhCzYTqXn4UsV6oAV)_