### PR TITLE
OG cards + sitemap + robots.txt + Taiwan in pull list

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ These document *why* the data pipeline looks the way it does. If a constraint ch
 - Top-level `scan_cursors` is per-media (`tv`, `movie`) so the two cycle independently.
 
 ### Region scope (multi-region rotating)
-- `TMDB_REGIONS` constant (currently `["US", "KR", "JP", "VN"]`) drives discovery scope. TMDb's `with_watch_providers` filter is region-specific, so each region gets scanned independently.
+- `TMDB_REGIONS` constant (currently `["US", "KR", "JP", "VN", "TW"]`) drives discovery scope. TMDb's `with_watch_providers` filter is region-specific, so each region gets scanned independently. Netflix doesn't operate in mainland China (CN); TW + HK cover Chinese-language Netflix content.
 - **Two-axis rotation:**
   - **Page cursor per (region, media):** stored in `shows.json` as `scan_cursors[region][media]`. Advances by `TMDB_PAGES_PER_RUN` each time the region is scanned.
   - **Region cursor:** stored as `scan_cursors["region_cursor"]` (an integer index into `TMDB_REGIONS`). Each run picks the next `TMDB_REGIONS_PER_RUN` regions starting from this cursor and advances modulo `len(TMDB_REGIONS)`.

--- a/app.js
+++ b/app.js
@@ -60,7 +60,7 @@
   // Popular section even when the catalog has no data backing them yet.
   const POPULAR_REGIONS = [
     "US", "GB", "CA", "BR", "MX", "DE", "FR", "IN",
-    "JP", "KR", "VN", "AU", "ES", "IT", "NL",
+    "JP", "KR", "TW", "VN", "AU", "ES", "IT", "NL",
   ];
 
   // ISO 3166 country code → 🇺🇸-style flag emoji via regional indicators.

--- a/index.html
+++ b/index.html
@@ -23,9 +23,29 @@
   <title>Top Netflix Shows by IMDb Rating</title>
   <meta name="description" content="An interactive ranking of Netflix originals and exclusives sorted by IMDb rating. Search, filter by genre, year, type and rating threshold." />
   <meta name="theme-color" content="#141414" />
-  <meta property="og:title" content="Top Netflix Shows by IMDb Rating" />
-  <meta property="og:description" content="Interactive ranking of Netflix originals and exclusives by IMDb rating." />
+
+  <!-- Canonical URL: prevents duplicate-indexing if anyone reaches the
+       site via the github.io URL or with tracking-style query strings. -->
+  <link rel="canonical" href="https://showranks.com/" />
+
+  <!-- Open Graph (Facebook, LinkedIn, iMessage, Slack, Discord). -->
+  <meta property="og:site_name" content="showranks" />
   <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://showranks.com/" />
+  <meta property="og:title" content="Top Netflix Shows by IMDb Rating" />
+  <meta property="og:description" content="Interactive ranking of Netflix originals and exclusives by IMDb rating. Filter by genre, language, region. Refreshed daily." />
+  <meta property="og:image" content="https://showranks.com/og-image.svg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:image:alt" content="showranks — Top Netflix Shows by IMDb Rating" />
+
+  <!-- Twitter / X large summary card. Uses the same OG image. -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Top Netflix Shows by IMDb Rating" />
+  <meta name="twitter:description" content="Interactive ranking of Netflix originals and exclusives by IMDb rating. Filter by genre, language, region. Refreshed daily." />
+  <meta name="twitter:image" content="https://showranks.com/og-image.svg" />
+  <meta name="twitter:image:alt" content="showranks — Top Netflix Shows by IMDb Rating" />
+
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23141414'/%3E%3Ctext x='50%25' y='58%25' text-anchor='middle' font-family='Arial' font-weight='900' font-size='20' fill='%23E50914'%3EN%3C/text%3E%3C/svg%3E" />
   <link rel="stylesheet" href="styles.css" />
 </head>

--- a/og-image.svg
+++ b/og-image.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" width="1200" height="630">
+  <!-- 1200×630 is the canonical og:image dimension. Designed to read
+       cleanly at small sizes (link-preview thumbnails) and at full
+       size (Twitter/X large-card previews). Inline SVG so we ship a
+       single file with no font dependency on the host platform. -->
+  <rect width="1200" height="630" fill="#0b0b0b"/>
+  <rect x="0" y="0" width="8" height="630" fill="#e50914"/>
+
+  <!-- Brand mark -->
+  <g transform="translate(80,100)">
+    <rect width="104" height="104" rx="18" fill="#e50914"/>
+    <text x="52" y="86" font-family="Helvetica, Arial, sans-serif" font-weight="900"
+          font-size="84" fill="#ffffff" text-anchor="middle">N</text>
+  </g>
+
+  <!-- Title -->
+  <text x="80" y="300" font-family="Helvetica, Arial, sans-serif" font-weight="800"
+        font-size="72" fill="#f5f5f5">Top Netflix Shows</text>
+  <text x="80" y="380" font-family="Helvetica, Arial, sans-serif" font-weight="800"
+        font-size="72" fill="#f5f5f5">by IMDb Rating</text>
+
+  <!-- Tagline -->
+  <text x="80" y="450" font-family="Helvetica, Arial, sans-serif" font-weight="400"
+        font-size="30" fill="#b3b3b3">Ranked daily. Filter by genre, language, region.</text>
+
+  <!-- Sample rating row -->
+  <g transform="translate(80, 525)">
+    <text font-family="Helvetica, Arial, sans-serif" font-weight="800" font-size="44"
+          fill="#f5c518">★ 9.5</text>
+    <text x="170" y="-4" font-family="Helvetica, Arial, sans-serif" font-weight="500"
+          font-size="28" fill="#b3b3b3">2.1M IMDb votes</text>
+  </g>
+
+  <!-- URL footer -->
+  <text x="1120" y="590" font-family="Helvetica, Arial, sans-serif" font-weight="700"
+        font-size="28" fill="#e50914" text-anchor="end">showranks.com</text>
+</svg>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,6 @@
+# Allow every crawler full access — the site is meant to be discoverable.
+User-agent: *
+Allow: /
+
+# Help search engines find the canonical URL.
+Sitemap: https://showranks.com/sitemap.xml

--- a/scripts/refresh_catalog.py
+++ b/scripts/refresh_catalog.py
@@ -43,14 +43,18 @@ TMDB_NETFLIX_NETWORK = 213      # Netflix as a TV network (originals)
 
 # Regions to scan, in order. Each region has its own scan cursor stored in
 # shows.json so they advance independently. Add codes here to expand the
-# catalog (e.g. "GB", "IN"); remove to narrow it.
-TMDB_REGIONS = ["US", "KR", "JP", "VN"]
+# catalog (e.g. "GB", "IN", "HK"); remove to narrow it.
+#
+# Note: Netflix doesn't operate in mainland China (CN) so it isn't here.
+# TW covers most Chinese-language content; add HK if/when Cantonese
+# coverage feels thin.
+TMDB_REGIONS = ["US", "KR", "JP", "VN", "TW"]
 
 # How many regions get scanned per run. The script rotates through
 # TMDB_REGIONS in order, scanning this many per run starting from the
 # stored region cursor. Set to len(TMDB_REGIONS) to scan everything every
 # run; set to 1 to be polite (one region per day).
-TMDB_REGIONS_PER_RUN = 4
+TMDB_REGIONS_PER_RUN = 5
 
 # TMDb response language. Affects returned title spelling; doesn't
 # restrict which content is returned.

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://showranks.com/</loc>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
Discoverability bundle:
- 1200x630 og-image.svg + Open Graph + Twitter Card meta tags + canonical URL
- sitemap.xml (daily changefreq matches the actual refresh cadence)
- robots.txt allowing all crawlers, pointing at the sitemap

Pull-list expansion:
- TMDB_REGIONS gains TW (Taiwan); CN isn't a Netflix market so adding it would be a no-op
- TMDB_REGIONS_PER_RUN bumped to 5 to keep scanning every region every run
- POPULAR_REGIONS in app.js gets TW so it surfaces in the dropdown's Popular section

12 tests still pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MLWi2WhCzYTqXn4UsV6oAV)_